### PR TITLE
change `info.date` to `info.x-date` in service specs

### DIFF
--- a/services/abc/abc.yaml
+++ b/services/abc/abc.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   version: 0.0.2
-  date: 10-30-2018
+  x-date: 10-30-2018
   title: abc
   description: |-
   

--- a/services/alias/alias.yaml
+++ b/services/alias/alias.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   version: 3.0.2
-  date: 10-30-2018
+  x-date: 10-30-2018
   title: alias
   description: |-
 

--- a/services/batchjob/batchjob.yaml
+++ b/services/batchjob/batchjob.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   version: 3.0.2
-  date: 10-30-2018
+  x-date: 10-30-2018
   title: batchjob
   description: |-
   

--- a/services/containers/containers.yaml
+++ b/services/containers/containers.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   version: 3.0.2
-  date: 10-30-2018
+  x-date: 10-30-2018
   title: containers
   description: |-
   

--- a/services/database/database.yaml
+++ b/services/database/database.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   version: 3.0.2
-  date: 10-30-2018
+  x-date: 10-30-2018
   title: database
   description: |-
   

--- a/services/default/default.yaml
+++ b/services/default/default.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   version: 3.0.2
-  date: 10-30-2018
+  x-date: 10-30-2018
   title: default
   description: |-
   

--- a/services/deployment/deployment.yaml
+++ b/services/deployment/deployment.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   version: 3.0.2
-  date: 10-30-2018
+  x-date: 10-30-2018
   title: deployment
   description: |-
   

--- a/services/example/example.yaml
+++ b/services/example/example.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   version: 3.0.2
-  date: 10-30-2018
+  x-date: 10-30-2018
   title: key
   description: |-
   

--- a/services/file/file.yaml
+++ b/services/file/file.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   version: 3.0.2
-  date: 10-30-2018
+  x-date: 10-30-2018
   title: file
   description: |-
   

--- a/services/filter/filter.yaml
+++ b/services/filter/filter.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   version: 3.0.2
-  date: 10-30-2018
+  x-date: 10-30-2018
   title: filter
   description: |-
   

--- a/services/flavor/flavor.yaml
+++ b/services/flavor/flavor.yaml
@@ -9,7 +9,7 @@ info:
     attributes that can be added. Flavors are essential to size a
     virtual cluster appropriately.
 
-    date: 10-30-2018
+    x-date: 10-30-2018
 
   termsOfService: 'https://github.com/cloudmesh-community/nist/blob/master/LICENSE.txt'
   contact:

--- a/services/health/health.yaml
+++ b/services/health/health.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   version: 3.0.2
-  date: 10-30-2018
+  x-date: 10-30-2018
   title: health
   description: |-
   

--- a/services/image/image.yaml
+++ b/services/image/image.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   version: 3.0.2
-  date: 10-30-2018
+  x-date: 10-30-2018
   title: abc
   description: |-
   

--- a/services/key/key.yaml
+++ b/services/key/key.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   version: 3.0.3
-  date: 11-06-2018
+  x-date: 11-06-2018
   title: key
   description: |-
   

--- a/services/keystore/keystore.yaml
+++ b/services/keystore/keystore.yaml
@@ -2,7 +2,7 @@
 swagger: '2.0'
 info:
   version: 3.0.3
-  date: 11-06-2018
+  x-date: 11-06-2018
   title: key
   description: |-
   

--- a/services/profile/profile.yaml
+++ b/services/profile/profile.yaml
@@ -2,7 +2,7 @@
 swagger: "2.0"
 info:
   version: 3.0.3
-  date: 11-06-2018
+  x-date: 11-06-2018
   title: "Profile"
   description: |-
   

--- a/services/replica/replica.yaml
+++ b/services/replica/replica.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   version: 3.0.2
-  date: 10-30-2018
+  x-date: 10-30-2018
   title: replica
   description: |-
   

--- a/services/reservation/reservation.yaml
+++ b/services/reservation/reservation.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   version: 3.0.2
-  date: 10-30-2018
+  x-date: 10-30-2018
   title: reservation
   description: |-
   

--- a/services/scheduler/scheduler.yaml
+++ b/services/scheduler/scheduler.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   version: 3.0.2
-  date: 10-30-2018
+  x-date: 10-30-2018
   title: scheduler
   description: |-
   

--- a/services/secgroup/secgroup.yaml
+++ b/services/secgroup/secgroup.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   version: 3.0.2
-  date: 10-30-2018
+  x-date: 10-30-2018
   title: secgroup
   description: |-
   

--- a/services/stream/stream.yaml
+++ b/services/stream/stream.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   version: 3.0.2
-  date: 10-30-2018
+  x-date: 10-30-2018
   title: stream
   description: |-
   

--- a/services/timestamp/timestamp.yaml
+++ b/services/timestamp/timestamp.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   version: 3.0.2
-  date: 10-30-2018
+  x-date: 10-30-2018
   title: timestamp
   description: |-
   

--- a/services/user/user.yaml
+++ b/services/user/user.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   version: 3.0.2
-  date: 10-30-2018
+  x-date: 10-30-2018
   title: user
   description: |-
   

--- a/services/virtualcluster/virtualcluster.yaml
+++ b/services/virtualcluster/virtualcluster.yaml
@@ -2,7 +2,7 @@
 swagger: "2.0"
 info:
   version: 3.0.3
-  date: 06-11-2018
+  x-date: 06-11-2018
   title: "Virtual Cluster"
   description: |-
 

--- a/services/virtualdirectory/virtualdirectory.yaml
+++ b/services/virtualdirectory/virtualdirectory.yaml
@@ -2,7 +2,7 @@
 swagger: '2.0'
 info:
   version: 3.0.3
-  date: 06-11-2018
+  x-date: 06-11-2018
   title: virtualdirectory
   description: |-
   

--- a/services/vm/vm.yaml
+++ b/services/vm/vm.yaml
@@ -5,7 +5,7 @@ info:
     A service to manage virtual machines
     
   version: 3.0.5
-  date: 11-16-2018
+  x-date: 11-16-2018
   title: Coludmesh VM
   termsOfService: 'https://github.com/cloudmesh-community/nist/blob/master/LICENSE.txt'
   contact:

--- a/services/vm/vm1.yaml
+++ b/services/vm/vm1.yaml
@@ -1,7 +1,7 @@
 swagger: "2.0"
 info:
   version: 3.0.2
-  date: 10-30-2018
+  x-date: 10-30-2018
   title: "Coludmesh Compute and Storage"
   description: |-
 


### PR DESCRIPTION
The `info.date` field causes a validation error `Schema error at info
should NOT have additional properties - additionalProperty: date`.

Changing to [a patterned object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#info-object).