### PR TITLE
Subgroup name

### DIFF
--- a/docs/nistvol8-2.md
+++ b/docs/nistvol8-2.md
@@ -105,7 +105,7 @@ especially the following NBD-PWG members:
 
 The *NIST Big Data Interoperability Framework (NBDIF): Volume 8,
 Reference Architecture Interfaces* document was prepared by the NIST
-Big Data Public Working Group (NBD-PWG) Interface Subgroup to identify
+Big Data Public Working Group (NBD-PWG) Reference Architecture Subgroup to identify
 interfaces in support of the NIST Big Data Reference Architecture
 (NBDRA) The interfaces contain two different aspects:
 


### PR DESCRIPTION
If the Executive Summary is identified as a header in the .md file, it seems to be contributing to the inaccurate section references that are generated in the pandoc conversion to docx process. Just bolding "Executive Summary" might help with this issue. For now, "Executive Summary" can be formatted in the docx output. However, a true automatic solution would be preferred. 