### PR TITLE
Scope section edits

### DIFF
--- a/docs/nistvol8-2.md
+++ b/docs/nistvol8-2.md
@@ -287,7 +287,7 @@ Data.
 
 Reference architectures provide "an authoritative source of information
 about a specific subject area that guides and constrains the
-instantiations of multiple architectures and solutions." (Reference needed) Reference
+instantiations of multiple architectures and solutions" [@www-dodaf-arch]. Reference
 architectures generally serve as a foundation for solution architectures
 and may also be used for comparison and alignment of instantiations of
 architectures and solutions.

--- a/docs/nistvol8-2.md
+++ b/docs/nistvol8-2.md
@@ -287,7 +287,7 @@ Data.
 
 Reference architectures provide "an authoritative source of information
 about a specific subject area that guides and constrains the
-instantiations of multiple architectures and solutions." Reference
+instantiations of multiple architectures and solutions." (Reference needed) Reference
 architectures generally serve as a foundation for solution architectures
 and may also be used for comparison and alignment of instantiations of
 architectures and solutions.
@@ -328,7 +328,7 @@ The NBDRA does not address the following:
 * Recommendations or standards for integration of infrastructure
   products.
 
-The goals of the Subgroup will be realized throughout the three planned
+The goals of the Subgroup were realized throughout the three planned
 phases of the NBD-PWG work, as outlined in @sec:production.
 
 ## Report Production {#sec:production}


### PR DESCRIPTION
For the quote in the first paragraph, do we have a source for this quote? If not, let's paraphrase it. Possibly "Reference architectures provide credible guidance and boundaries for architecture instantiations and solutions within a subject area."

The @sec:production does not create the correct section reference in the docx document (i.e., it says "... as outlined in sec. 5.3." but Section 5.3 does not contain the description of the three phases of the NBD-PWG work). Also, @sec:production comes out in the docx document as "sec. X.X" but it should be "Section X.X" this happens with the other @sec: references.