### PR TITLE
List of Specifications edits

### DIFF
--- a/docs/nistvol8-2.md
+++ b/docs/nistvol8-2.md
@@ -966,10 +966,10 @@ application requirements.
 
 ## List of specifications {#sec:spec-table}
 
-The following table lists the current set of resource objects that we
-are defining in this draft. Additional objects are also available at
+The following table lists the current set of resource objects that 
+are defined in this document. Additional objects are also available at
 
-* <https://github.com/cloudmesh-community/nist/tree/master/spec>
+<https://github.com/cloudmesh-community/nist/tree/master/spec>
 
 {include=./specstable.md}
 


### PR DESCRIPTION
The Specification Table should have a title and table number. Do we want to order the specifications within the table to match the order that we discuss them in the rest of the document?

Also, should there be two images (from ![Provider view]... and ![Resource view]...)? Only one image appears in the docx document.