### PR TITLE
Scheduler spec edits

### DIFF
--- a/spec/scheduler.yaml
+++ b/spec/scheduler.yaml
@@ -6,8 +6,8 @@ info:
   title: Scheduler
   description: |-
   
-    A service to store scheduler, value, type information. All of them
-    are stored as Strings.
+    The scheduler is a service to store scheduler, value, and type information, all of which
+    are stored as strings.
     
   termsOfService: 'https://github.com/cloudmesh-community/nist/blob/master/LICENSE.txt'
   contact:


### PR DESCRIPTION
Should the description be "The scheduler is a service to store **name**, value, and type information, all of which are stored as strings."?