### PR TITLE
Commenting out incomplete sections

### DIFF
--- a/docs/nistvol8-2.md
+++ b/docs/nistvol8-2.md
@@ -1209,13 +1209,13 @@ This section summarizes a basic interface specification of virtual machines.
 
 
 
-## Compute Management - Containers
+<!-- ## Compute Management - Containers -->
 
-This section is planned for a future version.
+<!-- This section is planned for a future version. -->
 
-## Compute Management - Functions
+<!-- ## Compute Management - Functions -->
 
-This section is planned for a future version.
+<!-- This section is planned for a future version. -->
 
 ## Others
 


### PR DESCRIPTION
The sections "Compute Management - Containers" and "Compute Management - Functions" only contain the following text "This section is planned for a future version." We are trying to remove references to future work from the volumes since, in theory, version 3 is the last version. Can we comment out these sections? The sections can be added back if content is developed during the public content period.