### PR TITLE
Others section

### DIFF
--- a/docs/nistvol8-2.md
+++ b/docs/nistvol8-2.md
@@ -1217,8 +1217,7 @@ This section is planned for a future version.
 
 This section is planned for a future version.
 
-## Others
-
-Please notify us if you would like to add other specifications.
+<!-- ## Others -->
+<!-- Please notify us if you would like to add other specifications. -->
 
 


### PR DESCRIPTION
The "Others" section probably should be removed since version 3 is, in theory, the last version of the document. However, if there are strong opinions to keep the section in the document, the text could be changed to "Please submit any additional specifications to the Reference Architecture Subgroup of the NBD-PWG."